### PR TITLE
feat: add login validation and logout button to dashboard page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.8.2",
+        "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.49.7",
         "next": "15.3.2",
         "react": "^19.0.0",
@@ -1056,6 +1057,33 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
+      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.7.0",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
+      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.14.4"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.69.1",
@@ -4197,6 +4225,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5411,6 +5448,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.49.7",
     "next": "15.3.2",
     "react": "^19.0.0",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+
+export default function DashboardPage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [userEmail, setUserEmail] = useState('')
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (!session) {
+        router.replace('/login')
+      } else {
+        setUserEmail(session.user.email || '')
+        setLoading(false)
+      }
+    }
+    checkSession()
+  }, [router])
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    router.push('/login')
+  }
+
+  if (loading) return <p className="p-8">Verificando autenticação...</p>
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-3xl font-bold">Welcome to your dashboard!</h1>
+      <p>Você está logado como: {userEmail}</p>
+
+      <button
+        onClick={handleLogout}
+        className="mt-4 bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition"
+      >
+        Sair
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
### ✅ What was done

- Added login validation logic using `supabase.auth.getSession()` to protect the dashboard page
- Implemented redirect to `/login` if no session is found
- Created a logout button that calls `supabase.auth.signOut()`
- After logout, user is redirected to the login screen

### 🧪 How to test

1. Go to `/login` and authenticate
2. Access `/dashboard`
3. The page should display the logged-in user's email
4. Click the "Logout" button
5. You should be redirected back to `/login`
6. Trying to access `/dashboard` again without logging in should send you back to `/login`

### 📌 Notes

- Session protection is handled client-side using React hooks
- This PR prepares the ground for persistent user state and dashboard-only features