### PR TITLE
feat: add PDF uploader

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import PDFuploader from '@/components/PDFUploader'
 
 export default function DashboardPage() {
   const router = useRouter()
@@ -29,6 +30,11 @@ export default function DashboardPage() {
 
   if (loading) return <p className="p-8">Verificando autenticação...</p>
 
+  const handlePDF = (file: File) => {
+
+    console.log(`Arquivo selecionado: ${file}`)
+  }
+
   return (
     <div className="p-8 space-y-4">
       <h1 className="text-3xl font-bold">Welcome to your dashboard!</h1>
@@ -40,6 +46,10 @@ export default function DashboardPage() {
       >
         Sair
       </button>
+      <div className="p-8 space-y-6">
+        <h1 className="text-2xl font-bold">Upload de PDF</h1>
+        <PDFuploader onFileSelect={handlePDF} />
+      </div>
     </div>
   )
 }

--- a/src/components/PDFUploader.tsx
+++ b/src/components/PDFUploader.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react"
+
+type Props = {
+  onFileSelect: (file: File) => void
+}
+
+export default function PDFuploader({ onFileSelect }: Props) {
+  const [fileName, setFileName] = useState('');
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && file.type == 'application/pdf') {
+      setFileName(file.name);
+      onFileSelect(file)
+    } else {
+      alert('Please, select a valid PDF file!')
+    }
+  }
+
+  return (
+    <div className="w-full max-w-sm space-y-2">
+      <label className="block text-sm font-medium">Enviar PDF</label>
+      <input
+        type="file"
+        accept="application/pdf"
+        onChange={handleFileChange}
+        className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4
+          file:rounded file:border-0 file:text-sm file:font-semibold
+          file:bg-purple-50 file:text-purple-700 hover:file:bg-purple-100"
+      />
+      {fileName && <p className="text-xs text-gray-600">Selecionado: {fileName}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
- Created a reusable `PDFUploader` component in `src/components`
- Allows users to select and upload PDF files
- Validates file type to ensure only PDFs are accepted
- Displays the name of the selected file
- Exposes `onFileSelect` callback to handle selected file logic